### PR TITLE
Update pre-typed selector hook name

### DIFF
--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -339,7 +339,7 @@ This can also be done inline as well:
 const isOn = useSelector((state: RootState) => state.isOn)
 ```
 
-However, prefer creating a pre-typed `useSelector` hook with the correct type of `state` built-in instead.
+However, prefer creating a pre-typed `useAppSelector` hook with the correct type of `state` built-in instead.
 
 ### Typing the `useDispatch` hook
 


### PR DESCRIPTION
For docs consistency.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ x] Is there an existing issue for this PR?
  - No issue
- [ x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Code Quality
- **Page**: Usage with TypeScript

## What is the problem?

Inconsistency. Maybe just a typo. There is written _"prefer creating a pre-typed `useSelector` hook with the correct type"_ in the block "Typing the useSelector hook". When in the next block about `useDispatch` it says this: _"prefer creating a pre-typed `useAppDispatch` hook with the correct type"_. Both are correct, I guess. First one is like "... pre-typed **version of** `useSelector` hook ...", and second one is about the hook defined already. But I think the second one is clearer, because it refers a reader to the information he have read above.

## What changes does this PR make to fix the problem?

Change the name.
